### PR TITLE
Add cross-link to LOLA from the Data Portability draft report

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,17 @@
         latestVersion: "https://swicg.github.io/activitypub-data-portability/",
         shortName: "data-portability-report",
         group: "socialcg",
+        otherLinks: [
+          {
+            key: "Related documents",
+            data: [
+              {
+                value: "LOLA Portability for Activity Pub (0.2)",
+                href: "https://swicg.github.io/activitypub-data-portability/lola",
+              },
+            ],
+          },
+        ]
       };
     </script>
   </head>


### PR DESCRIPTION
There wasn't an easy way to find the LOLA draft specification from the report, despite them being part of the same taskforce, this adds an entry to the header where the editors / github links are titled "Related documents" with the LOLA document linked.

This helps folks more easily find the LOLA draft specification from the main website for this taskforce