### PR TITLE
Pr for migration endpoints

### DIFF
--- a/lola.html
+++ b/lola.html
@@ -781,7 +781,7 @@
       <h4>Change Type Activities</h4>
 
       <p>
-        Add, Update, Undo, Remove, Tombstone and Delete activities should not be copied.  Rather than propagate these, the 
+        Add, Update, Undo, Remove and Delete activities should not be copied.  Rather than propagate these, the 
         results of changes SHOULD be provided by the source server.  
       </p>
 
@@ -793,7 +793,7 @@
       </p>
 
       <p>
-        Another example, if a server posts a Note then replaces that with a Tombstone activity, the Tombstone activity 
+        Another example, if a server posts a Note then replaces that with a Tombstone object, the Tombstone object 
         SHOULD be omitted by the source and SHOULD NOT be copied by the destination.  
       </p>
 
@@ -841,7 +841,6 @@
       <p>
         <b>Question</b> activities SHOULD be copied but the destination MAY close them when copying if they are not closed.
       </p>
-
 
       <h3>
         Load Management During Fetdching of Content

--- a/lola.html
+++ b/lola.html
@@ -783,8 +783,8 @@
       <h4>Change Type Activities</h4>
 
       <p>
-        Add, Update, Undo, Remove and Delete activities should not be copied.  Rather than propagate these, the 
-        results of changes SHOULD be provided by the source server.  
+        Add, Update, Undo, Remove, and Delete activities should not be copied.  Rather than propagate these, the
+        source server SHOULD provide the <em>results</em> of changes.
       </p>
 
       <p>

--- a/lola.html
+++ b/lola.html
@@ -647,7 +647,7 @@
         This collection SHOULD contain a filtered view of all the actor's activities that the source server deems eligible for migration.  The source server MAY filter out activities that are not relevant to the destination server, or that the user has chosen to exclude during the OAuth authorization step.
 	  </p>
       <p>
-        When migrating user's data, the destination server MUST use the migration outbox in lieu of the regular outbox if the migration outbox URL is different.  This allows the source server some flexibility that may be important, in how it fetches and 
+        When migrating user data, the destination server MUST use the migration outbox in lieu of the regular outbox if the migration outbox URL is different.  This allows the source server some flexibility that may be important, in how it fetches and 
         presents data for account migration differently than for regular use.
       </p>
 

--- a/lola.html
+++ b/lola.html
@@ -641,8 +641,10 @@
 
       <h3>Migration Outbox</h3>
 	  <p>
-		The migration outbox is intended as a simple way for applications to enable LOLA account migration.  Servers implementing LOLA MUST include this collection in actor's profiles, as it will provide maximum compatibility with other ActivityPub software.
-		This collection SHOULD contain a filtered view of all the actor's activities that the source server deems eligible for migration.  The source server MAY filter out activities that are not relevant to the destination server, or that the user has chosen to exclude during the OAuth authorization step.
+		The migration outbox is intended as a simple way for applications to enable LOLA account migration.  Servers implementing LOLA MUST include this collection in actor profiles, as it will provide maximum compatibility with other ActivityPub software.
+	  </p>
+      <p>
+        This collection SHOULD contain a filtered view of all the actor's activities that the source server deems eligible for migration.  The source server MAY filter out activities that are not relevant to the destination server, or that the user has chosen to exclude during the OAuth authorization step.
 	  </p>
       <p>
         When migrating user's data, the destination server MUST use the migration outbox in lieu of the regular outbox if the migration outbox URL is different.  This allows the source server some flexibility that may be important, in how it fetches and 

--- a/lola.html
+++ b/lola.html
@@ -673,7 +673,7 @@
 		  objects, along with any application-specific objects that also contain user-generated content.
         </li>
         <li>
-          Media objects (such as images, videos, or audio files) that are hosted by the source server - if it is a resource that would go away if the source 
+          Media objects (such as image, video, or audio files) that are hosted by the source server — if it is a resource that would go away if the source 
           server were to receive an account deletion request, then it should be here for fetching over.
         </li>
       </ul>

--- a/lola.html
+++ b/lola.html
@@ -507,17 +507,21 @@
     "accountPortabilityOauth": "https://example.com/oauth2/porting-access-endpoint",
     "inbox": "https://oakfrost.example.com/brock/inbox",
     "outbox": "https://oakfrost.example.com/brock/outbox",
-    "content": "https://oakfrost.example.com/brock/content",
     "following": "https://oakfrost.example.com/brock/following",
     "followers": "https://oakfrost.example.com/brock/followers",
     "liked": "https://oakfrost.example.com/brock/liked",
     "blocked": "https://oakfrost.example.com/brock/blocked",
-    "migration": "https://oakfrost.example.com/brock/outbox"
+    "migration": {
+        "outbox": "https://oakfrost.example.com/brock/migration/outbox",
+        "content": "https://oakfrost.example.com/brock/migration/content",
+        "app:other": "https://oakfrost.example.com/brock/migration/app-specific-collection"
+    }
 }
 </pre>
 
     <p>Notes</p>
       <ul>
+		<li>The "migration" property contains all of the collections that can be migrated from this source actor.  This document specifies the "migration outbox" and the "content collection", which are both defined below. Applications MAY define their own application-specific collections, which will be defined more rigorously in a future version of this specification.</li>
         <li>
           Actor names (not only the 'name' property but also the portion of the Actor ID that contains the name if applicable) may differ at the source and destination, and may be different than the names used as user identifiers by either system.  A user with an account identity such as “Alice” may transfer the “DeepThoughts” actor data on server A “@deepthoughts@a.example” to a “PhilosophicalMusings” actor owned by the account “AMuse” “@philomuse@b.example”, as long as she can log into both accounts and has permissions to authorize the transfer on both ends.
         </li>
@@ -635,28 +639,44 @@
         suspension. 
       </p>
 
-
       <h3>Migration Outbox</h3>
+	  <p>
+		The migration outbox is intended as a simple way for applications to enable LOLA account migration.  Servers implementing LOLA MUST include this collection in actor's profiles, as it will provide maximum compatibility with other ActivityPub software.
+		This collection SHOULD contain a filtered view of all the actor's activities that the source server deems eligible for migration.  The source server MAY filter out activities that are not relevant to the destination server, or that the user has chosen to exclude during the OAuth authorization step.
+	  </p>
       <p>
-        The destination server MUST use the migration outbox in lieu of the regular outbox if the migration outbox URL 
-        is different.  This allows the source server some flexibility that may be important, in how it fetches and 
+        When migrating user's data, the destination server MUST use the migration outbox in lieu of the regular outbox if the migration outbox URL is different.  This allows the source server some flexibility that may be important, in how it fetches and 
         presents data for account migration differently than for regular use.
       </p>
 
       <h3>Content Collection</h3>
 
+	  <p>The content collection represents the <i>current state</i> of all of the actor's content, separate from the specific Activities (such as `Create`, `Delete`, `Undo`, and `Update`) that have been performed on the objects during their lifetimes.</p>
       <p>
-        The source server SHOULD include these object types in the content collection:
+        The source server SHOULD include object types such as these in the content collection:
       </p>
       <ul>
-        <li>
-          Note and other Activity types that have content.
+        <li>All objects owned by the user, such as  
+          <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-article" target="_blank">Article</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-audio" target="_blank">Audio</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-document" target="_blank">Document</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-event" target="_blank">Event</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-image" target="_blank">Image</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-note" target="_blank">Note</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-page" target="_blank">Page</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-place" target="_blank">Place</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-profile" target="_blank">Profile</a>, 
+		  <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-relationship" target="_blank">Relationship</a>, 
+		  and <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-video" target="_blank">Video</a> 
+		  objects, along with any application-specific objects that also contain user-generated content.
         </li>
         <li>
-          Media objects that are hosted by the source server - if it is a resource that would go away if the source 
+          Media objects (such as images, videos, or audio files) that are hosted by the source server - if it is a resource that would go away if the source 
           server were to receive an account deletion request, then it should be here for fetching over.
         </li>
       </ul>
+
+	  <p>The source server SHOULD NOT include <a href="https://www.w3.org/TR/activitystreams-vocabulary/#dfn-tombstone" target="_blank">Tombstone</a> objects in the content collection.</p>
 
       <p>
         The source server MUST NOT include content wrapper or content modification activities in the content collection, 
@@ -693,7 +713,7 @@
       </p>
 
       <p>
-        Open Issues:  Is there a way to negotiate what extended features are recognized and whether the source should downgrade structured info?  Is there already a way to request posts in one format or another? 
+        Open Issues:  Is there a way to negotiate what extended features are recognized and whether the source should downgrade structured info?  Is there already a way to request posts in one format or another? -- Perhaps this is addressed by the ability to defined additional collections in the "migration" property.
       </p>
 
       <h3>Actor Information</h3>

--- a/lola.html
+++ b/lola.html
@@ -715,7 +715,7 @@
       </p>
 
       <p>
-        Open Issues:  Is there a way to negotiate what extended features are recognized and whether the source should downgrade structured info?  Is there already a way to request posts in one format or another? -- Perhaps this is addressed by the ability to defined additional collections in the "migration" property.
+        Open Issues:  Is there a way to negotiate the extended features that are recognized and/or whether the source should downgrade structured info?  Is there already a way to request posts in one format or another? — Perhaps this is addressed by the ability to define additional collections in the "migration" property?
       </p>
 
       <h3>Actor Information</h3>

--- a/lola.html
+++ b/lola.html
@@ -795,8 +795,8 @@
       </p>
 
       <p>
-        Another example, if a server posts a Note then replaces that with a Tombstone object, the Tombstone object 
-        SHOULD be omitted by the source and SHOULD NOT be copied by the destination.  
+        Another example: If a server posts a Note and then replaces that with a Tombstone object, the Tombstone object
+        SHOULD be omitted by the source and SHOULD NOT be copied by the destination.
       </p>
 
       <p>

--- a/lola.html
+++ b/lola.html
@@ -482,7 +482,7 @@
 
       <h3>Role of destination server in discovery</h3>
 
-      <p>If the destination server finds the account portability OAuth endpoint via the [RFC8414] ".well-known" approach, it MUST gain authorization and use its account migration authorization token when doing feature discovery.   </p>
+      <p>If the destination server finds the account portability OAuth endpoint via the [RFC8414] ".well-known" approach, it MUST gain authorization and use its account migration authorization token when doing feature discovery.</p>
 
       <p>If the destination server requests the Actor object before gaining authorization, it MUST request the Actor object again using its account migration authorization token to do feature discovery.</p>
 
@@ -514,6 +514,8 @@
     "migration": {
         "outbox": "https://oakfrost.example.com/brock/migration/outbox",
         "content": "https://oakfrost.example.com/brock/migration/content",
+        "following": "https://oakfrost.example.com/brock/migration/following",
+        "blocked": "https://oakfrost.example.com/brock/migration/blocked",
         "app:other": "https://oakfrost.example.com/brock/migration/app-specific-collection"
     }
 }
@@ -521,7 +523,11 @@
 
     <p>Notes</p>
       <ul>
-		<li>The "migration" property contains all of the collections that can be migrated from this source actor.  This document specifies the "migration outbox" and the "content collection", which are both defined below. Applications MAY define their own application-specific collections, which will be defined more rigorously in a future version of this specification.</li>
+		<li>The "migration" property contains all of the data that can be migrated from this source actor.</li>
+		<li>The "migration" property SHOULD include a "migration outbox" (defined below) that allows target servers to pull all activities from the source server. Target servers SHOULD use this outbox to import all of the actor's previous activities.</li>  
+		<li>The "migration" property SHOULD include a "content collection" (defined below) that includes all of the content associated with this actor (posts, uploads, etc). Target servers SHOULD use this collection to import all of the actor's content.</li>
+		<li>The "migration" property SHOULD include "following" and "blocked" collections, which mirror the actor's public "following" and "blocked" collections. These are listed here so that the source server can explicitly declare the data that can be migrated. In some instances, the contents of these "migration" collections may be different from the publicly available collections -- for example, if an actor has "blocked" someone but has not published this to their public profile.</li>
+		<li>Applications MAY define additional collections to be migrated, and these will be defined more rigorously in a future version of this specification.</li>
         <li>
           Actor names (not only the 'name' property but also the portion of the Actor ID that contains the name if applicable) may differ at the source and destination, and may be different than the names used as user identifiers by either system.  A user with an account identity such as “Alice” may transfer the “DeepThoughts” actor data on server A “@deepthoughts@a.example” to a “PhilosophicalMusings” actor owned by the account “AMuse” “@philomuse@b.example”, as long as she can log into both accounts and has permissions to authorize the transfer on both ends.
         </li>
@@ -532,7 +538,6 @@
           URL discovery allows the account migration “outbox” to be different from the normal outbox if the source server prefers to implement it at a different URL, but it can also be the same URL.  There may be a number of differences between migration outbox and regular outbox, caused by permissions settings, filtering unnecessary items, filters explicitly chosen by the user, or other reasons we can't foresee now.  That said, a simple implementation can probably be successful using the same URL for both. 
         </li>
       </ul>
-
 
     </section>
 
@@ -721,15 +726,15 @@
       <h3>Actor Information</h3>
 
       <p>
-        The <b>Following</b> collection as per 
-        <a href="https://www.w3.org/TR/activitypub/#following">https://www.w3.org/TR/activitypub/#following</a> SHOULD be 
-        provided on the Actor object when accessed with the account migration authorization token.  
+        The new migration property includes a <b>Following</b> collection that mirrors the publicly available 
+        <a href="https://www.w3.org/TR/activitypub/#following">Following</a> property. This new property is
+		used so that source servers can provide additional information that may not be accessible in the publicly available collection. For instance, some "following" records may not be visible publicly, but may still need to be transferred to the destination server. In this case, the "un-published" follows would appear in the migration collection even if they do not appear on the source server.
       </p>
 
       <p>
-        If the source server does blocking, the personal block list SHOULD be fetchable at the URL advertised on the Actor 
-        object, as per <a href="https://codeberg.org/fediverse/fep/src/branch/main/fep/c648/fep-c648.md"
-        >https://codeberg.org/fediverse/fep/src/branch/main/fep/c648/fep-c648.md</a>
+        The new migration property also includes a <b>Blocked</b> collection that mirrors the publicly available
+		<a href="https://codeberg.org/fediverse/fep/src/branch/main/fep/c648/fep-c648.md">Blocked</a> property.
+		If the actor has a personal block list, then this information SHOULD be fetchable from this property.  This new property is used so that source servers can provide additional information that may not be accessible in the publicly available collection. For instance, actors may "block" others without publishing this information on their profile. In this case, the "un-published" block would appear in the migration collection even if it does not appear on the source server.
       </p>
 
       <p>


### PR DESCRIPTION
This addresses #42 by moving new collections into the `migration` property in the Actor's profile, along with some explanatory text about how these collections behave.

I added one note to the "Open Issues" section: I believe the issue of negotiating extended data formats is addressed by the ability to define custom collections within the `migration` property. I've left this lightly defined right now, awaiting your feedback. Ideally, we should define a strict process that uses `@context` property to declare these app-specific collections. If you'd like, just say "go" and I'll take a shot at this, too.

As always, please let me know if there's anything I should change and I'll happily make edits.